### PR TITLE
Fix unbounded NuGet cache growth in Azure pipelines

### DIFF
--- a/.azure/azure-pipelines/nightly-release.yml
+++ b/.azure/azure-pipelines/nightly-release.yml
@@ -36,12 +36,14 @@ stages:
         parameters:
           dotnetPostFix: 'money-erp'
 
+      # Exact-match key only - no restoreKeys on purpose. A fallback key restores
+      # the previous package set, `dotnet restore` layers the new packages on top
+      # and the post-job saves the union, so the cache grows without bound
+      # (it had reached 14 GB while a clean restore needs ~1.3 GB).
       - task: Cache@2
+        displayName: 'Cache NuGet packages'
         inputs:
-          key: 'nuget | "$(Agent.OS)" | **/packages.lock.json'
-          restoreKeys: |
-            nuget | "$(Agent.OS)"
-            nuget
+          key: 'nuget | v2 | "$(Agent.OS)" | **/packages.lock.json'
           path: $(NUGET_PACKAGES)
 
       - script: dotnet --info

--- a/.azure/azure-pipelines/release.yml
+++ b/.azure/azure-pipelines/release.yml
@@ -36,12 +36,14 @@ stages:
         parameters:
           dotnetPostFix: 'money-erp'
 
+      # Exact-match key only - no restoreKeys on purpose. A fallback key restores
+      # the previous package set, `dotnet restore` layers the new packages on top
+      # and the post-job saves the union, so the cache grows without bound
+      # (it had reached 14 GB while a clean restore needs ~1.3 GB).
       - task: Cache@2
+        displayName: 'Cache NuGet packages'
         inputs:
-          key: 'nuget | "$(Agent.OS)" | **/packages.lock.json'
-          restoreKeys: |
-            nuget | "$(Agent.OS)"
-            nuget
+          key: 'nuget | v2 | "$(Agent.OS)" | **/packages.lock.json'
           path: $(NUGET_PACKAGES)
 
       - script: dotnet --info

--- a/.azure/azure-pipelines/unit-tests.yml
+++ b/.azure/azure-pipelines/unit-tests.yml
@@ -49,12 +49,14 @@ stages:
         parameters:
           dotnetPostFix: 'money-erp'
 
+      # Exact-match key only - no restoreKeys on purpose. A fallback key restores
+      # the previous package set, `dotnet restore` layers the new packages on top
+      # and the post-job saves the union, so the cache grows without bound
+      # (it had reached 14 GB while a clean restore needs ~1.3 GB).
       - task: Cache@2
+        displayName: 'Cache NuGet packages'
         inputs:
-          key: 'nuget | "$(Agent.OS)" | **/packages.lock.json'
-          restoreKeys: |
-            nuget | "$(Agent.OS)"
-            nuget
+          key: 'nuget | v2 | "$(Agent.OS)" | **/packages.lock.json'
           path: $(NUGET_PACKAGES)
 
       - script: dotnet --info


### PR DESCRIPTION
## Problem

The NuGet cache in the Azure pipelines had grown to **14.19 GB**, while a clean restore of the solution needs only **1.3 GB** — an 11x bloat. Fetching it dominates every build.

Measured on builds [60361](https://dev.azure.com/aviationexam/Web%20app/_build/results?buildId=60361), [60327](https://dev.azure.com/aviationexam/Web%20app/_build/results?buildId=60327) and [60226](https://dev.azure.com/aviationexam/Web%20app/_build/results?buildId=60226):

| Step | Duration |
| --- | --- |
| `Cache` (restore — 7.6 GB physical / 14.4 GB logical, 137k chunks) | 197–256 s, **every build** |
| `Post-job: Cache` (tar 14.19 GB + upload) | 198–284 s whenever the lock files change (4 s on an exact hit) |
| Everything else (SDK setup, GitVersion, schema fetch, restore, build, test) | ~180 s |
| **Total** | **420–640 s** |

The cache costs more than the entire rest of the pipeline. `Restore` itself only takes 14–17 s.

## Root cause

`restoreKeys` made the cache grow monotonically:

1. `packages.lock.json` changes (Dependabot, roughly weekly) → the primary key misses.
2. The fallback `restoreKeys` (`nuget | "Linux"`, then `nuget`) hit the **previous** cache, so the old package set is unpacked into `$(NUGET_PACKAGES)`.
3. `dotnet restore` layers the new versions on top — nothing is removed.
4. The post-job saves the **union** under the new key.

Nothing is ever evicted, so every dependency bump ratchets the cache upward. Since the key is derived from the lock files, a fallback key can only ever supply packages the current lock files do not ask for.

## Fix

- **Drop `restoreKeys`.** Exact-match-only means each entry holds exactly what the current lock files need, keeping it bounded at the real restore footprint.
- **Bump the key prefix to `v2`** so the existing 14 GB entries are abandoned outright instead of being inherited one more time.
- Applied to all three pipelines (`unit-tests`, `nightly-release`, `release`), which shared the same block.

A YAML comment records why `restoreKeys` is deliberately absent — it is the pattern Microsoft's own NuGet-caching docs recommend, so it is easy to re-add by accident.

## Expected result

| | Before | After |
| --- | --- | --- |
| Cache size | 14.19 GB | ~1.3 GB |
| `Cache` restore | 197–256 s | ~20–30 s |
| `Post-job: Cache` on lock change | 198–284 s | ~15–25 s |

Roughly **3 minutes saved on every build**, and ~7 minutes on dependency-bump builds.

The trade-off is that a lock-file change now pays a clean ~1.3 GB restore instead of a partial one. That is strictly cheaper than restoring and re-saving a 14 GB cache, and it is what keeps the cache from growing again.

## Notes / follow-up (not in this PR)

`src/WarningConfiguration.targets` sets `<RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>`, which pulls runtime packs for both RIDs across net8.0/net9.0/net10.0 — ~1.05 GB of the 1.3 GB restore, including ~560 MB of Windows packs that a Linux agent never uses:

```
386M  microsoft.netcore.app.runtime.win-x64      (8.0.29, 9.0.18, 10.0.10)
383M  microsoft.netcore.app.runtime.linux-x64
121M  microsoft.aspnetcore.app.runtime.win-x64
112M  microsoft.aspnetcore.app.runtime.linux-x64
 53M  microsoft.netcore.app.host.win-x64
```

Dropping `win-x64` would roughly halve the cache again, but it changes what the build validates (AOT/trimming analysis for Windows), so it is left as a separate decision.

## Verification

- All three pipeline files parse as valid YAML.
- All three resolve to a single identical cache key, with zero `restoreKeys`.
- No line-ending churn in the diff.
- Restore footprint measured locally with a clean `NUGET_PACKAGES` folder: `dotnet restore` → 1.3 GB.